### PR TITLE
Simplify event aliases handling

### DIFF
--- a/src/prism.rb
+++ b/src/prism.rb
@@ -191,14 +191,12 @@ module Prism
         end
 
         result[:on] ||= {}
-        result[:on][:click] = options[:onClick].to_hash if options[:onClick]
-        result[:on][:change] = options[:onChange].to_hash if options[:onChange]
-        result[:on][:input] = options[:onInput].to_hash if options[:onInput]
-        result[:on][:mousedown] = options[:onMousedown].to_hash if options[:onMousedown]
-        result[:on][:mouseup] = options[:onMouseup].to_hash if options[:onMouseup]
-        result[:on][:keydown] = options[:onKeydown].to_hash if options[:onKeydown]
-        result[:on][:keyup] = options[:onKeyup].to_hash if options[:onKeyup]
-        result[:on][:scroll] = options[:onScroll].to_hash if options[:onScroll]
+
+        events_options = options.select { |key, value| key.to_s.start_with?('on') }
+        events_options.each do |key, value|
+          event_name = key.to_s.sub(/on/, '').downcase.to_sym
+          result[:on][event_name] = value.to_hash
+        end
 
         if options[:on]
           event_handlers = {}

--- a/src/prism.rb
+++ b/src/prism.rb
@@ -192,9 +192,10 @@ module Prism
 
         result[:on] ||= {}
 
-        events_options = options.select { |key, value| key.to_s.start_with?('on') }
-        events_options.each do |key, value|
-          event_name = key.to_s.sub(/on/, '').downcase.to_sym
+        options.each do |key, value|
+          key_as_string = key.to_s
+          next unless key_as_string.start_with?('on')
+          event_name = key_as_string.sub(/on/, '').downcase
           result[:on][event_name] = value.to_hash
         end
 


### PR DESCRIPTION
I came up with a simple solution. If you want to keep the list of allowed event I'd add a list same as html tags and then do a intersection with options provided by user. As far as I can see this is not the case for events defined with `:on` and that's why I came up with this solution. :wink: 